### PR TITLE
specify which part goes into podspec and which into container spec

### DIFF
--- a/05-configuration/readme.md
+++ b/05-configuration/readme.md
@@ -24,7 +24,7 @@ data:
     tcp-backlog 128
 ```
 
-Add the following snippets to the redis container specification:
+Add the following snippets to the redis **container** specification:
 
 ```yaml
 command: ["redis-server"]
@@ -34,7 +34,7 @@ volumeMounts:
     mountPath: /tmp/
 ```
 
-and this:
+and this into the redis **pod** specification::
 
 ```yaml
 volumes:


### PR DESCRIPTION
The description is a little misleading, as both parts are described a belonging to container-spec. The later is for podspec.